### PR TITLE
Support `git commit --amend`

### DIFF
--- a/hooks/pre_commit.go
+++ b/hooks/pre_commit.go
@@ -54,11 +54,6 @@ func PreCommit(c *context.Context, opts *PreCommitOpts) error {
 		return err
 	}
 
-	if len(files) == 0 {
-		color.Yellow("No files to be committed!")
-		os.Exit(NOTHING_STAGED_EXIT_CODE)
-	}
-
 	executables, err := c.ExecutablesForHook(PRE_COMMIT_HOOK)
 	if err != nil {
 		return err

--- a/spec/pre_commit_spec.rb
+++ b/spec/pre_commit_spec.rb
@@ -90,4 +90,14 @@ describe 'pre-commit' do
 
     expect(result.status).to eq 0
   end
+
+  it 'passes if no files to be committed' do
+    system 'git commit --message "Commit example" --quiet --no-verify'
+
+    # No file changes, emulating a `git commit --amend`.
+    result = run_hook
+
+    expect(result.status).to eq 0
+    expect(result.lines).to eq([])
+  end
 end


### PR DESCRIPTION
Files may not be changed when amending, e.g. when modifying commit metadata only.

No files changed should be treated as success, not a failure case.
