### PR TITLE
Color auto-detects TTY

### DIFF
--- a/hooks/commit_msg.go
+++ b/hooks/commit_msg.go
@@ -19,6 +19,10 @@ type CommitMsgOpts struct {
 }
 
 func CommitMsg(c *context.Context, opts *CommitMsgOpts) error {
+	if opts.NoColor {
+		color.NoColor = true
+	}
+
 	executables, err := c.ExecutablesForHook(HOOK)
 	if err != nil {
 		return err

--- a/hooks/pre_commit.go
+++ b/hooks/pre_commit.go
@@ -47,7 +47,9 @@ func (opts *PreCommitOpts) ListFiles(c *context.Context) ([]string, error) {
 }
 
 func PreCommit(c *context.Context, opts *PreCommitOpts) error {
-	color.NoColor = opts.NoColor
+	if opts.NoColor {
+		color.NoColor = true
+	}
 
 	files, err := opts.ListFiles(c)
 	if err != nil {


### PR DESCRIPTION
Only set `color.NoColor` if we explicitly set `--no-color`, ensuring we fall back to the default value, which is only true if stdout is a TTY.

Fixes #2 
