### PR TITLE
Run pre-commit hook's preamble steps in parallel

### DIFF
--- a/hooks/pre_commit.go
+++ b/hooks/pre_commit.go
@@ -3,11 +3,14 @@ package hooks
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
+	"github.com/samber/lo"
 	lop "github.com/samber/lo/parallel"
 
 	"github.com/dirk/quickhook/repo"
+	"github.com/dirk/quickhook/tracing"
 )
 
 const PRE_COMMIT_HOOK = "pre-commit"
@@ -16,41 +19,62 @@ const PRE_COMMIT_MUTATING_HOOK = "pre-commit-mutating"
 const FAILED_EXIT_CODE = 65         // EX_DATAERR - hooks didn't pass
 const NOTHING_STAGED_EXIT_CODE = 66 // EX_NOINPUT
 
-type Opts struct {
-	NoColor bool
-}
-
 type PreCommit struct {
 	Repo *repo.Repo
-	Opts
 }
 
-func (hook *PreCommit) Run(files []string) error {
-	dirForPath, err := hook.Repo.ShimGit()
+// argsFiles can be non-empty with the files passed in by the user when manually running this hook,
+// or it can be empty and the list of files will be retrieved from Git.
+func (hook *PreCommit) Run(argsFiles []string) error {
+	// Resolve files to be committed in parallel with shimming git.
+	filesChan := lo.Async2(func() ([]string, error) {
+		if len(argsFiles) > 0 {
+			return argsFiles, nil
+		}
+		if files, err := hook.Repo.FilesToBeCommitted(); err != nil {
+			return nil, err
+		} else {
+			return files, nil
+		}
+	})
+	shimChan := lo.Async2(shimGit)
+	mutatingChan := lo.Async2(func() ([]string, error) {
+		return hook.Repo.FindHookExecutables(PRE_COMMIT_MUTATING_HOOK)
+	})
+	parallelChan := lo.Async2(func() ([]string, error) {
+		return hook.Repo.FindHookExecutables(PRE_COMMIT_HOOK)
+	})
+
+	dirForPath, err := (<-shimChan).Unpack()
 	if err != nil {
 		return err
 	}
+	// Check the shimChan first so that if we did successfully create a directory with a shim we
+	// can make sure to clean it up if anything else errored.
 	defer os.RemoveAll(dirForPath)
+	files, err := (<-filesChan).Unpack()
+	if err != nil {
+		return err
+	}
+	mutatingExecutables, err := (<-mutatingChan).Unpack()
+	if err != nil {
+		return err
+	}
+	parallelExecutables, err := (<-parallelChan).Unpack()
+	if err != nil {
+		return err
+	}
 
 	stdin := strings.Join(files, "\n")
 
-	// Find any mutating hooks and run them first sequentially.
-	mutatingExecutables, err := hook.Repo.FindHookExecutables(PRE_COMMIT_MUTATING_HOOK)
-	if err != nil {
-		return err
-	}
+	// Run mutating executables sequentially.
 	for _, executable := range mutatingExecutables {
 		result := runExecutable(hook.Repo.Root, executable, os.Environ(), stdin)
 		if hook.checkResult(result) {
 			os.Exit(FAILED_EXIT_CODE)
 		}
 	}
-
-	parallelExecutables, err := hook.Repo.FindHookExecutables(PRE_COMMIT_HOOK)
-	if err != nil {
-		return err
-	}
-	// Run hook executables in parallel.
+	// And the rest in parallel.
 	results := lop.Map(parallelExecutables, func(executable string, _ int) hookResult {
 		// Insert the git shim's directory into the PATH to prevent usage of git.
 		env := append(os.Environ(), fmt.Sprintf("PATH=%s:%s", dirForPath, os.Getenv("PATH")))
@@ -77,4 +101,26 @@ func (hook *PreCommit) checkResult(result hookResult) bool {
 	result.printStderr()
 	result.printStdout()
 	return true
+}
+
+func shimGit() (string, error) {
+	span := tracing.NewSpan("shim-git")
+	defer span.End()
+
+	dir, err := os.MkdirTemp("", "quickhook-git-*")
+	if err != nil {
+		return "", err
+	}
+
+	git := path.Join(dir, "git")
+	err = os.WriteFile(git, []byte(strings.Join([]string{
+		"#!/bin/sh",
+		"echo \"git is not allowed in parallel hooks (git $@)\"",
+		"exit 1",
+		"",
+	}, "\n")), 0755)
+	if err != nil {
+		return "", err
+	}
+	return dir, nil
 }

--- a/quickhook.go
+++ b/quickhook.go
@@ -60,10 +60,7 @@ func main() {
 		defer finish()
 	}
 
-	opts := hooks.Opts{
-		NoColor: cli.NoColor,
-	}
-	if opts.NoColor {
+	if cli.NoColor {
 		color.NoColor = true
 	}
 
@@ -105,19 +102,8 @@ func main() {
 			panic(err)
 		}
 
-		files := cli.Hook.PreCommit.Files
-		if len(files) == 0 {
-			files, err = repo.FilesToBeCommitted()
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		hook := hooks.PreCommit{
-			Repo: repo,
-			Opts: opts,
-		}
-		err = hook.Run(files)
+		hook := hooks.PreCommit{Repo: repo}
+		err = hook.Run(cli.Hook.PreCommit.Files)
 		if err != nil {
 			panic(err)
 		}

--- a/repo/git.go
+++ b/repo/git.go
@@ -1,10 +1,6 @@
 package repo
 
 import (
-	"os"
-	"path"
-	"strings"
-
 	"github.com/samber/lo"
 
 	"github.com/dirk/quickhook/tracing"
@@ -21,27 +17,4 @@ func (repo *Repo) FilesToBeCommitted() ([]string, error) {
 		isFile, _ := repo.isFile(line)
 		return isFile
 	}), err
-}
-
-func (repo *Repo) ShimGit() (string, error) {
-	span := tracing.NewSpan("git shim")
-	defer span.End()
-
-	dir, err := os.MkdirTemp("", "quickhook-git-*")
-	if err != nil {
-		return "", err
-	}
-
-	git := path.Join(dir, "git")
-	err = os.WriteFile(git, []byte(strings.Join([]string{
-		"#!/bin/sh",
-		"echo \"git is not allowed in parallel hooks (git $@)\"",
-		"exit 1",
-		"",
-	}, "\n")), 0755)
-	if err != nil {
-		return "", err
-	}
-
-	return dir, nil
 }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/dirk/quickhook/tracing"
 )
 
 type Repo struct {
@@ -27,8 +29,10 @@ func NewRepo() (*Repo, error) {
 }
 
 func (repo *Repo) FindHookExecutables(hook string) ([]string, error) {
-	dir := path.Join(".quickhook", hook)
+	span := tracing.NewSpan("find " + hook)
+	defer span.End()
 
+	dir := path.Join(".quickhook", hook)
 	var infos []fs.FileInfo
 	{
 		f, err := os.Open(path.Join(repo.Root, dir))

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -33,7 +33,7 @@ func (span *Span) Elapsed() time.Duration {
 var spans []*Span
 
 func Start() func() {
-	spans = make([]*Span, 0)
+	spans = []*Span{}
 	return func() {
 		fmt.Printf("Traced %v span(s):\n", len(spans))
 		for _, span := range spans {


### PR DESCRIPTION
The preamble steps in the pre-commit hook (`git diff`, discovering the list of hook executables, shimming Git) are all IO-bound, so we can run them in parallel.