### PR TITLE
Make it easier to work with refs and versions when preparing for release

### DIFF
--- a/.github/workflows/release-build-linux.yml
+++ b/.github/workflows/release-build-linux.yml
@@ -3,10 +3,6 @@ name: build-linux
 on:
   workflow_call:
     inputs:
-      tag:
-        description: "Tag to checkout and build"
-        type: string
-        required: true
       version:
         description: "Version without the leading 'v'"
         type: string
@@ -21,8 +17,6 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: '${{ inputs.tag }}'
       - uses: actions/setup-go@v3
         with:
           go-version: '1.20'
@@ -30,6 +24,8 @@ jobs:
         with:
           ruby-version: '3.1'
       - run: gem install fpm
+      - name: Set version
+        run: sed -i "s/VERSION = \"main\"/VERSION = \"${{ inputs.version }}\"/" quickhook.go
       - name: Build
         run: |
           mkdir -p build/usr/bin

--- a/.github/workflows/release-verify-deb-ubuntu.yml
+++ b/.github/workflows/release-verify-deb-ubuntu.yml
@@ -12,13 +12,13 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: debs
-    - run: |
-        dpkg --info quickhook-${{ inputs.version }}-amd64.deb
-        dpkg --contents quickhook-${{ inputs.version }}-amd64.deb
-        sudo apt install ./quickhook-${{ inputs.version }}-amd64.deb
-    - run: |
-        quickhook --version
-        [[ $(quickhook --version) == "${{ inputs.version }}" ]]
+      - uses: actions/download-artifact@v3
+        with:
+          name: debs
+      - run: |
+          dpkg --info quickhook-${{ inputs.version }}-amd64.deb
+          dpkg --contents quickhook-${{ inputs.version }}-amd64.deb
+          sudo apt install ./quickhook-${{ inputs.version }}-amd64.deb
+      - run: |
+          quickhook --version
+          [[ $(quickhook --version) == "${{ inputs.version }}" ]]

--- a/.github/workflows/release-verify-rpm-rhel.yml
+++ b/.github/workflows/release-verify-rpm-rhel.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     container: redhat/ubi8-minimal:latest
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: rpms
-    - run: |
-        rpm --package quickhook-${{ inputs.version }}-amd64.rpm --query --info
-        rpm --package quickhook-${{ inputs.version }}-amd64.rpm --query --list
-        rpm --install quickhook-${{ inputs.version }}-amd64.rpm
-    - run: |
-        quickhook --version
-        [[ $(quickhook --version) == "${{ inputs.version }}" ]]
+      - uses: actions/download-artifact@v3
+        with:
+          name: rpms
+      - run: |
+          rpm --package quickhook-${{ inputs.version }}-amd64.rpm --query --info
+          rpm --package quickhook-${{ inputs.version }}-amd64.rpm --query --list
+          rpm --install quickhook-${{ inputs.version }}-amd64.rpm
+      - run: |
+          quickhook --version
+          [[ $(quickhook --version) == "${{ inputs.version }}" ]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: release
-run-name: Prepare ${{ inputs.tag }} for release
+run-name: Prepare ${{ inputs.version }} for release
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag to release'
+      version:
+        description: 'Version'
         type: string
         required: true
 
@@ -15,13 +15,15 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+      # It's easier to work with the version when we've stripped the leading
+      # "v" off of it.
       - id: version
-        run: echo "${{ inputs.tag }}" | sed -E "s/^v?/version=/" >> $GITHUB_OUTPUT
+        run: |
+          echo "${{ inputs.version }}" | sed -E "s/^v?/version=/" >> $GITHUB_OUTPUT
   build-linux:
     uses: ./.github/workflows/release-build-linux.yml
     needs: version
     with:
-      tag: ${{ inputs.tag }}
       version: ${{ needs.version.outputs.version }}
   verify-deb-ubuntu:
     uses: ./.github/workflows/release-verify-deb-ubuntu.yml

--- a/quickhook.go
+++ b/quickhook.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dirk/quickhook/tracing"
 )
 
-const VERSION = "1.6.0"
+const VERSION = "main"
 
 var cli struct {
 	Install struct {


### PR DESCRIPTION
Enables building a release from a branch rather than having to use a version tag.