### PR TITLE
Allow Git read commands in parallel hooks

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,13 +17,11 @@ jobs:
       - name: Build and test with integration coverage
         run: |
           go build -cover -v
-          mkdir -p coverage
-          GOCOVERDIR=$(pwd)/coverage go test ./... -v -count=1
-          go tool covdata textfmt -i=coverage -o coverage-integration.txt
+          mkdir -p coverage/integration
+          GOCOVERDIR="$(pwd)/coverage/integration" go test ./... -v -count=1
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: coverage-integration.txt
+          path: coverage
   test-cover-build:
     runs-on: ubuntu-latest
     steps:
@@ -34,26 +32,21 @@ jobs:
       - name: Build and test with unit coverage
         run: |
           go build -v
-          go test ./... -v -count=1 -coverprofile=coverage-unit.txt
+          mkdir -p coverage/unit
+          go test ./... -v -count=1 -cover -args -test.gocoverdir="$PWD/coverage/unit"
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: coverage-unit.txt
+          path: coverage
   coverage:
     runs-on: ubuntu-latest
     needs: [test-cover-integration, test-cover-build]
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
-        with:
-          name: coverage
       - name: Process coverage
-        # Coverage is simple text files, so we can combine the integration
-        # and unit test coverage by simply appending the latter with the
-        # first line skipped.
         run: |
-          cp coverage-integration.txt coverage.txt
-          tail -n +2 coverage-unit.txt >> coverage.txt
+          go tool covdata textfmt -i=./artifact/unit,./artifact/integration -o=coverage.txt
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverage.txt
+          file: ./coverage.txt

--- a/hooks/pre_commit_git_shim.sh
+++ b/hooks/pre_commit_git_shim.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+COMMAND=$1
+shift
+if
+    [ "$COMMAND" = "diff" ] ||
+    [ "$COMMAND" = "ls-files" ] ||
+    [ "$COMMAND" = "rev-list" ] ||
+    [ "$COMMAND" = "rev-parse" ] ||
+    [ "$COMMAND" = "show" ] ||
+    [ "$COMMAND" = "status" ];
+then
+    # The Git executable below will be replaced at runtime when shimming.
+    ACTUAL_GIT "$COMMAND" "$@"
+    exit 0
+fi
+COMBINED=$(echo "$COMMAND  $*" | xargs)
+echo "git is not allowed in parallel hooks (git $COMBINED)"
+exit 1


### PR DESCRIPTION
It'd be nice to still be able to do some basic readonly operations during a hook to get the status of the repo. This therefore tweaks the shim to allow `diff`, `show`, `status`, and some common plumbing commands used in hooks on through to Git.

Fixes #20.