### PR TITLE
Permit `git grep` in pre-commit shim

### DIFF
--- a/hooks/pre_commit_git_shim.sh
+++ b/hooks/pre_commit_git_shim.sh
@@ -4,6 +4,7 @@ COMMAND=$1
 shift
 if
     [ "$COMMAND" = "diff" ] ||
+    [ "$COMMAND" = "grep" ] ||
     [ "$COMMAND" = "ls-files" ] ||
     [ "$COMMAND" = "rev-list" ] ||
     [ "$COMMAND" = "rev-parse" ] ||


### PR DESCRIPTION
Allows another read command reported in #20.