### PR TITLE
fix: fix shim return status (return gits)

### DIFF
--- a/hooks/pre_commit_git_shim.sh
+++ b/hooks/pre_commit_git_shim.sh
@@ -13,7 +13,7 @@ if
 then
     # The Git executable below will be replaced at runtime when shimming.
     ACTUAL_GIT "$COMMAND" "$@"
-    exit 0
+    exit $?
 fi
 COMBINED=$(echo "$COMMAND  $*" | xargs)
 echo "git is not allowed in parallel hooks (git $COMBINED)"


### PR DESCRIPTION
I noticed that the return code isn't forwarded by the shim. Didn't notice a particular bug nor tested the solution, but this makes more sense to me.