### PR TITLE
Permit `git cat-file` in pre-commit shim

### DIFF
--- a/hooks/pre_commit_git_shim.sh
+++ b/hooks/pre_commit_git_shim.sh
@@ -3,6 +3,7 @@ set -e
 COMMAND=$1
 shift
 if
+    [ "$COMMAND" = "cat-file" ] ||
     [ "$COMMAND" = "diff" ] ||
     [ "$COMMAND" = "grep" ] ||
     [ "$COMMAND" = "ls-files" ] ||

--- a/hooks/pre_commit_test.go
+++ b/hooks/pre_commit_test.go
@@ -133,6 +133,9 @@ func TestGitShimAllowsReadonlyAccess(t *testing.T) {
 	tempDir := initGitForPreCommit(t)
 	tempDir.MkdirAll(".quickhook", "pre-commit")
 	tempDir.WriteFile([]string{".quickhook", "pre-commit", "accesses-git"}, "#!/bin/sh \n git status")
+	tempDir.WriteFile(
+		[]string{".quickhook", "pre-commit", "reads-blobs"},
+		"#!/bin/sh \n echo :0:example.txt | git cat-file --batch")
 
 	output, err := tempDir.ExecQuickhook("hook", "pre-commit")
 	assert.Nil(t, err)


### PR DESCRIPTION
Ran into this with a pre-commit hook that compares the HEAD and staged versions of the files being committed. It reads the blobs with `git cat-file --batch`, which the shim currently rejects (`git is not allowed in parallel hooks (git cat-file --batch)`).

cat-file is read-only, same family as the commands allowed in #21 and #24.