### PR TITLE
Release darwin binaries and tarballs

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [linux]
+        os: [linux, darwin]
         arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
-      - uses: ruby/setup-ruby@v1.146.0
+      - uses: ruby/setup-ruby@v1
+        if: ${{ matrix.os == 'linux' }}
         with:
           ruby-version: '3.1'
       - run: gem install fpm
+        if: ${{ matrix.os == 'linux' }}
       - name: Set version
         run: sed -i "s/VERSION = \"[^\"]*\"/VERSION = \"${{ inputs.version }}\"/" quickhook.go
       - name: Build
@@ -54,12 +56,15 @@ jobs:
             --version ${{ inputs.version }} \
             --architecture ${{ matrix.arch }} \
             --chdir build .
-      # - name: Copy binaries
-      #   if: ${{ matrix.os == 'darwin' }}
-      #   run: |
-      #     cp build/usr/bin/quickhook quickhook-${{ matrix.os }}-${{ matrix.arch }}
-      - uses: actions/upload-artifact@v3
+      # Binary at the archive root so tool managers (e.g. mise's github
+      # backend) find the executable without path overrides.
+      - name: Package tarballs
+        run: |
+          tar -czf quickhook-${{ inputs.version }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz -C build/usr/bin quickhook
+      - uses: actions/upload-artifact@v4
         with:
+          name: release-${{ matrix.os }}-${{ matrix.arch }}
           path: |
             *.deb
             *.rpm
+            *.tar.gz

--- a/.github/workflows/release-verify-deb-ubuntu.yml
+++ b/.github/workflows/release-verify-deb-ubuntu.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: release-linux-*
+          merge-multiple: true
       - run: |
           dpkg --info quickhook-${{ inputs.version }}-linux-amd64.deb
           dpkg --contents quickhook-${{ inputs.version }}-linux-amd64.deb

--- a/.github/workflows/release-verify-rpm-rhel.yml
+++ b/.github/workflows/release-verify-rpm-rhel.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: release-linux-*
+          merge-multiple: true
       - run: |
           rpm --package quickhook-${{ inputs.version }}-linux-amd64.rpm --query --info
           rpm --package quickhook-${{ inputs.version }}-linux-amd64.rpm --query --list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,26 @@ jobs:
     needs: [version, build]
     with:
       version: ${{ needs.version.outputs.version }}
+  # Draft a release with all verified assets attached; publishing stays a
+  # human step. Skipped on non-main refs so test dispatches of this workflow
+  # only build and verify.
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref_name == github.event.repository.default_branch
+    needs: [version, verify-deb-ubuntu, verify-rpm-rhel]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+      - name: Draft release with assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.version.outputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --draft \
+            --generate-notes \
+            *.deb *.rpm *.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,18 @@ jobs:
       - id: version
         run: |
           echo "${{ inputs.version }}" | sed -E "s/^v?/version=/" >> $GITHUB_OUTPUT
-  build-linux:
+  build:
     uses: ./.github/workflows/release-build.yml
     needs: version
     with:
       version: ${{ needs.version.outputs.version }}
   verify-deb-ubuntu:
     uses: ./.github/workflows/release-verify-deb-ubuntu.yml
-    needs: [version, build-linux]
+    needs: [version, build]
     with:
       version: ${{ needs.version.outputs.version }}
   verify-rpm-rhel:
     uses: ./.github/workflows/release-verify-rpm-rhel.yml
-    needs: [version, build-linux]
+    needs: [version, build]
     with:
       version: ${{ needs.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ $ brew install quickhook
 Tarballs for Linux and macOS, plus installable debs and RPMs for Linux, are available for the [latest release](https://github.com/dirk/quickhook/releases/latest). Assets are named `quickhook-<version>-<os>-<arch>` with `linux`/`darwin` and `amd64`/`arm64`. (Tarballs ship starting with the first release after v1.6.2; debs and RPMs are already available.)
 
 ```sh
-# Installing a tarball (the binary sits at the archive root)
-curl -LO https://github.com/dirk/quickhook/releases/download/v1.6.2/quickhook-1.6.2-darwin-arm64.tar.gz
-tar -xzf quickhook-1.6.2-darwin-arm64.tar.gz quickhook  # then move it onto your $PATH
+# Installing a tarball (the binary sits at the archive root);
+# substitute the latest release's version for <version>
+curl -LO https://github.com/dirk/quickhook/releases/download/v<version>/quickhook-<version>-darwin-arm64.tar.gz
+tar -xzf quickhook-<version>-darwin-arm64.tar.gz quickhook  # then move it onto your $PATH
 
 # Installing a .deb
 curl -LO https://github.com/dirk/quickhook/releases/download/v1.6.2/quickhook-1.6.2-linux-amd64.deb

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ brew install quickhook
 
 ### Binary downloads
 
-Tarballs for Linux and macOS, plus installable debs and RPMs for Linux, are available for the [latest release](https://github.com/dirk/quickhook/releases/latest). Assets are named `quickhook-<version>-<os>-<arch>` with `linux`/`darwin` and `amd64`/`arm64`.
+Tarballs for Linux and macOS, plus installable debs and RPMs for Linux, are available for the [latest release](https://github.com/dirk/quickhook/releases/latest). Assets are named `quickhook-<version>-<os>-<arch>` with `linux`/`darwin` and `amd64`/`arm64`. (Tarballs ship starting with the first release after v1.6.2; debs and RPMs are already available.)
 
 ```sh
 # Installing a tarball (the binary sits at the archive root)

--- a/README.md
+++ b/README.md
@@ -62,18 +62,28 @@ $ brew install quickhook
 /opt/homebrew/Cellar/quickhook/1.6.2: 6 files, 3.8MB, built in 5 seconds
 ```
 
-### Linux
+### Binary downloads
 
-Installable debs and RPMs are available for the [latest release](https://github.com/dirk/quickhook/releases/latest).
+Tarballs for Linux and macOS, plus installable debs and RPMs for Linux, are available for the [latest release](https://github.com/dirk/quickhook/releases/latest). Assets are named `quickhook-<version>-<os>-<arch>` with `linux`/`darwin` and `amd64`/`arm64`.
 
 ```sh
+# Installing a tarball (the binary sits at the archive root)
+curl -LO https://github.com/dirk/quickhook/releases/download/v1.6.2/quickhook-1.6.2-darwin-arm64.tar.gz
+tar -xzf quickhook-1.6.2-darwin-arm64.tar.gz quickhook  # then move it onto your $PATH
+
 # Installing a .deb
-wget https://github.com/dirk/quickhook/releases/download/v1.5.0/quickhook-1.5.0-amd64.deb
-sudo apt install ./quickhook-1.5.0-amd64.deb
+curl -LO https://github.com/dirk/quickhook/releases/download/v1.6.2/quickhook-1.6.2-linux-amd64.deb
+sudo apt install ./quickhook-1.6.2-linux-amd64.deb
 
 # Installing a .rpm
-wget https://github.com/dirk/quickhook/releases/download/v1.5.0/quickhook-1.5.0-amd64.rpm
-sudo rpm --install quickhook-1.5.0-amd64.rpm
+curl -LO https://github.com/dirk/quickhook/releases/download/v1.6.2/quickhook-1.6.2-linux-amd64.rpm
+sudo rpm --install quickhook-1.6.2-linux-amd64.rpm
+```
+
+Or let [mise](https://mise.jdx.dev) fetch the right tarball for your platform:
+
+```sh
+$ mise use --global github:dirk/quickhook
 ```
 
 ## Usage


### PR DESCRIPTION
Closes #32.

This finishes the darwin stub that's been commented out in `release-build.yml` since 9e39eaa (2023) — the deb/rpm steps were already `if: matrix.os == 'linux'`-guarded, so darwin slots straight into the matrix.

## What

**Commit 1 — darwin + tarballs + pipeline repair:**
- `os: [linux, darwin]` in the build matrix; every os/arch pair now also produces `quickhook-<version>-<os>-<arch>.tar.gz` with the binary at the archive root (where tool managers like mise's github backend expect it — `mise use github:dirk/quickhook` resolves these with no overrides, and archives outrank the .deb in its asset scoring). Linux tarballs also give bare-binary installs a path that doesn't need dpkg/rpm.
- Repairs the release pipeline, which fails today on retired actions: `upload-artifact@v3` (retired Jan 2025; dependabot only bumped the download half) → `v4` with per-matrix `name: release-<os>-<arch>` (v4 artifacts are immutable per name), verify workflows download with `pattern: release-linux-*` + `merge-multiple: true`. `setup-go@v3` → `v7` and `ruby/setup-ruby@v1.146.0` → `v1` (the v3 runner detection hard-fails on current images).
- README: "Linux" → "Binary downloads", fixes the stale v1.5.0 pre-`linux`-naming URLs, adds tarball + mise instructions. (Tarball URLs will resolve from the next release onward.)
- Renames `build-linux` → `build` since it's no longer linux-only.

**Commit 2 — severable if you'd rather keep hand-rolled uploads:** a `publish` job in `release.yml` (needs both verifies, `contents: write`) that downloads all `release-*` artifacts and drafts the GitHub release with `--generate-notes` and every asset attached — publishing the draft stays a human step. Gated to main, so test dispatches only build and verify.

## Evidence

Dispatched `release.yml` on this branch with a throwaway version (`v1.6.2.test3`, at the current head): https://github.com/dirk/quickhook/actions/runs/30329291457 — all four build jobs and both verifies green, publish skipped (off-main as designed). Downloaded the artifacts: `quickhook-<version>-darwin-arm64.tar.gz` contains a Mach-O 64-bit arm64 executable at the archive root that runs on my Mac and reports the test version; linux artifacts carry .deb, .rpm, and .tar.gz each.

(Unrelated, deliberately not touched: go-install builds report `--version` as "main" since VERSION is sed-rewritten only at release build.)
